### PR TITLE
Update README instructions for building

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ newer version.
 ## Build it
 
 ```sh
-clojure -X:dev:build
+clj -X:build :project-dir "\"$(pwd)\""
 ```
 
 will create `target/sudoku.metabase-driver.jar`. Copy this file to `/path/to/metabase/plugins/` and restart your


### PR DESCRIPTION
we used to allow relative project settings when building, and the
exec-args passed in `:project-dir "."` But in
https://github.com/metabase/metabase/pull/17608 we removed this ability
and require absolute paths.

First party paths use the hardcoded "drivers/modules/<driver-name>"
absolute path but third party drivers (like sudoku here) must pass in a
project dir at the moment.

Ideally we can fix the backend build scripts. They feel a bit "how we
build our drivers" and not amenable to how arbitrary drivers are built.