### PR TITLE
Fix native query shape

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 /.nrepl-port
 .cpcache
 .class
+
+# lsp: ignore all but the config file
+.lsp/*
+!.lsp/config.edn
+.clj-kondo/.cache

--- a/src/metabase/driver/sudoku.clj
+++ b/src/metabase/driver/sudoku.clj
@@ -43,10 +43,10 @@
   [_driver {{source-table-id :source-table} :query, :as mbql-query}]
   (println "MBQL query:")
   (pprint/pprint mbql-query)
-  (:name (qp.store/table source-table-id)))
+  {:query (:name (qp.store/table source-table-id))})
 
 (defmethod driver/execute-reducible-query :sudoku
-  [_driver {difficulty :native, :as query} _context respond]
+  [_driver {{difficulty :query} :native, :as query} _context respond]
   (println "Native query:" (pr-str (select-keys query [:native])))
   (let [metadata (sudoku.qp/column-metadata)
         rows     (sudoku.qp/random-board-rows (keyword difficulty))]


### PR DESCRIPTION
The `driver/mbql->native` used to just return "hard" etc. But this now
blows up in how we normalize native queries:

```clojure
;;; native query schema from schema.cljc
(def NativeQuery
  "Schema for a valid, normalized native [inner] query."
  {:query                          s/Any
   (s/optional-key :template-tags) TemplateTagMap
   ;; collection (table) this query should run against. Needed for MongoDB
   (s/optional-key :collection)    (s/maybe helpers/NonBlankString)
   ;; other stuff gets added in my different bits of QP middleware to record bits of state or pass info around.
   ;; Everyone else can ignore them.
   s/Keyword                       s/Any})

;;; normalize native query turns string keys of map into keywords
(defn- normalize-native-query
  "For native queries, normalize the top-level keys, and template tags, but nothing else."
  [native-query]
  (let [native-query (m/map-keys maybe-normalize-token native-query)]
    (cond-> native-query
      (seq (:template-tags native-query)) (update :template-tags normalize-template-tags))))
```

Not 100% clear if we really want to allow arbitrary shapes for native
queries or if they should be a map. I think we want to be a map based on
the spec though.

### Before

<img width="922" alt="image" src="https://user-images.githubusercontent.com/6377293/166831143-705aaa07-b9f3-43bb-aa99-fd86366ea825.png">

<img width="922" alt="image" src="https://user-images.githubusercontent.com/6377293/166831569-d322c51b-1dec-427e-8631-d24fab0c4f2a.png">


### After


<img width="922" alt="image" src="https://user-images.githubusercontent.com/6377293/166831238-f207ffe1-d318-48f8-b346-849269cce3f6.png">

<img width="922" alt="image" src="https://user-images.githubusercontent.com/6377293/166831388-847375bd-2826-4dda-8b71-9b065a6415a9.png">
